### PR TITLE
feat: branch-level aliases (LOC->LOCATION, ORG->ORGANIZATION)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 ## Version 0.3.2
 
+### Features
+
+- **Branch-level aliases** — non-leaf hierarchy nodes can now declare raw aliases via a reserved `_aliases` key (e.g. `"LOCATION": {"_aliases": ["LOC"], ...}`), mirroring the alias lists that leaf nodes already have. `add_alias()` on a branch node now records the alias instead of creating a spurious child leaf. The reserved key is skipped by every tree-walk, so it never becomes a canonical entity.
+
+### Breaking Changes
+
+- **`LOC` and `ORG` are no longer canonical entities** — they were empty leaf nodes under `LOCATION`/`ORGANIZATION` and are now branch-level aliases of them. Coarse dataset labels like TAB's `LOC`/`ORG` therefore match a model's `LOCATION`/`ORGANIZATION` at the exact (leaf) level, not only at the branch level. Concretely:
+  - `canonicalize("LOC")` returns `"LOCATION"` (was `"LOC"`), and likewise for `ORG`.
+  - `LOC`/`ORG` no longer appear in `all_canonical_entities` or `canonical_to_branch`.
+  - `get_depth("LOC")` returns `2` (was `3`), because `LOC` now denotes the depth-2 `LOCATION` branch.
+  - `CanonicalMapper.map()` no longer accepts `LOC`/`ORG` as resolution *targets*, since targets must be canonical entities. Such mappings are also no longer needed — the labels resolve on their own.
+  - `to_branch("LOC")` still returns `"LOCATION"`, unchanged.
+
+### Behavior Changes
+
+- **`to_branch()` and `get_depth()` now resolve raw aliases**, not just canonical names. Previously a raw alias (e.g. `COMPANYNAME`, `QQ`) was passed through unchanged by `to_branch` and raised in `get_depth`; both now resolve it first. Unknown labels are still returned as-is by `to_branch`.
+- **`add_alias()` accepts an alias as its subject**, so `add_alias("LOC", ...)` works as well as `add_alias("LOCATION", ...)`.
+- **`add_alias()` now raises `ValueError` instead of silently no-opping** when the alias is already claimed by a descendant of the target (e.g. adding `CITY` to the `LOCATION` branch, where `CITY` already resolves to `ADDRESS`). The hierarchy is left unmodified. It also raises `KeyError` if the reserved `_aliases` key is passed as the entity name.
+
 ### Bug Fixes
 
 - **Span merging no longer depends on the DataFrame index** — `SpanEvaluator` mixed sentence-relative token positions with DataFrame index labels when checking whether two same-type spans are adjacent. With the global index produced by `predict_dataset()`, the between-tokens lookup read the wrong rows — or none at all — for every sentence except the one starting at row 0, and an empty lookup counts as "adjacent", silently merging same-type spans separated by regular words (e.g. the two PERSON spans in "John visited Berlin with Mary" became one). Span counts (`num_annotated`, `num_predicted`, `true_positives`) were deflated symmetrically for gold and predictions, so headline precision/recall could still look plausible. The evaluator now uses sentence-relative positions throughout and produces identical results for any DataFrame index.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,19 @@
 
 ### Breaking Changes
 
-- **`LOC` and `ORG` are no longer canonical entities** — they were empty leaf nodes under `LOCATION`/`ORGANIZATION` and are now branch-level aliases of them. Coarse dataset labels like TAB's `LOC`/`ORG` therefore match a model's `LOCATION`/`ORGANIZATION` at the exact (leaf) level, not only at the branch level. Concretely:
-  - `canonicalize("LOC")` returns `"LOCATION"` (was `"LOC"`), and likewise for `ORG`.
-  - `LOC`/`ORG` no longer appear in `all_canonical_entities` or `canonical_to_branch`.
-  - `get_depth("LOC")` returns `2` (was `3`), because `LOC` now denotes the depth-2 `LOCATION` branch.
-  - `CanonicalMapper.map()` no longer accepts `LOC`/`ORG` as resolution *targets*, since targets must be canonical entities. Such mappings are also no longer needed — the labels resolve on their own.
-  - `to_branch("LOC")` still returns `"LOCATION"`, unchanged.
+- **`LOC`, `ORG` and `PER` are no longer canonical entities** — they were empty leaf nodes under `LOCATION`/`ORGANIZATION`/`PERSON` > `NAME` and are now branch-level aliases of `LOCATION`/`ORGANIZATION`/`PERSON`. Coarse dataset labels like TAB's `LOC`/`ORG`/`PER` therefore match a model's `LOCATION`/`ORGANIZATION`/`PERSON` at the exact (leaf) level, not only at the branch level. Concretely:
+  - `canonicalize("LOC")` returns `"LOCATION"` (was `"LOC"`), and likewise for `ORG` and `PER`.
+  - `LOC`/`ORG`/`PER` no longer appear in `all_canonical_entities` or `canonical_to_branch`.
+  - `get_depth("LOC")` returns `2` (was `3`), because `LOC` now denotes the depth-2 `LOCATION` branch. `get_depth("PER")` returns `2` (was `3`).
+  - `CanonicalMapper.map()` no longer accepts `LOC`/`ORG`/`PER` as resolution *targets*, since targets must be canonical entities. Such mappings are also no longer needed — the labels resolve on their own.
+  - `to_branch("LOC")` still returns `"LOCATION"`, unchanged; `to_branch("PER")` still returns `"PERSON"`.
 
 ### Behavior Changes
 
 - **`to_branch()` and `get_depth()` now resolve raw aliases**, not just canonical names. Previously a raw alias (e.g. `COMPANYNAME`, `QQ`) was passed through unchanged by `to_branch` and raised in `get_depth`; both now resolve it first. Unknown labels are still returned as-is by `to_branch`.
 - **`add_alias()` accepts an alias as its subject**, so `add_alias("LOC", ...)` works as well as `add_alias("LOCATION", ...)`.
-- **`add_alias()` now raises `ValueError` instead of silently no-opping** when the alias is already claimed by a descendant of the target (e.g. adding `CITY` to the `LOCATION` branch, where `CITY` already resolves to `ADDRESS`). The hierarchy is left unmodified. It also raises `KeyError` if the reserved `_aliases` key is passed as the entity name.
+- **`add_alias()` now raises `ValueError` instead of silently no-opping** when the alias is already claimed by a descendant of the target (e.g. adding `CITY` to the `LOCATION` branch, where `CITY` already resolves to `ADDRESS`). The hierarchy is left unmodified — an alias the target already owns is preserved. It also raises `KeyError` if the reserved `_aliases` key is passed as the entity name.
+- **A branch alias shadowed by one of its own descendants logs a warning at construction time**, so collisions declared statically in `definitions.py` are no longer silent.
 
 ### Bug Fixes
 

--- a/docs/entity_hierarchy.md
+++ b/docs/entity_hierarchy.md
@@ -24,11 +24,70 @@ Examples:
 - `CREDITCARD`, `credit_card` → case and delimiters don't matter, becomes `FINANCIAL`
 
 **Phase 2 — Project:** canonical entities are projected onto the *canonical surface* — a set of entities at a
-depth computed by majority vote from the **dataset annotation labels**. Depth-2 ancestors that have
-multiple depth-3 descendants trigger a `COLLISION_AMBIGUOUS` issue; descendants that have exactly
-one matching ancestor on the canonical surface are auto-fixed as `COLLISION_TRIVIAL`.
+depth computed by majority vote from the **dataset annotation labels**. A label that sits on the same
+branch as its co-occurring annotations but at a different depth (e.g. prediction `PERSON` vs annotation
+`NAME`) is reported as `COLLISION_SAME_BRANCH` (INFO) and handled automatically by hierarchical
+evaluation. A label on a *different* branch is reported as `COLLISION_CROSS_BRANCH` (WARNING) and
+must be resolved with `map()`.
 
 Labels that can't be resolved automatically are flagged for you to handle manually.
+
+## Aliases
+
+An alias is a raw label that resolves to a canonical entity. Aliases are how the same concept written
+different ways (`EMAIL`, `email_address`, `EMAILADDRESS`) all reach one canonical name. Matching is
+normalized — case, underscores, dashes and BIO prefixes are ignored.
+
+**Leaf aliases** are declared as the list value of a leaf node:
+
+```python
+"EMAIL_ADDRESS": ["EMAIL", "EMAILADDRESS", "E_MAIL"]
+```
+
+**Branch aliases** are declared with the reserved `_aliases` key, so a non-leaf node can carry synonyms
+of its own:
+
+```python
+"LOCATION": {
+    "_aliases": ["LOC"],      # LOC resolves to LOCATION itself
+    "ADDRESS": {...},
+    "GPE": [...],
+}
+```
+
+This matters for coarse corpora. TAB, for example, labels entities `LOC`/`ORG`/`PER`; without branch
+aliases those could only ever match a model's `LOCATION`/`ORGANIZATION`/`PERSON` at the *branch*
+level, understating exact-level scores. The reserved key is skipped by every tree-walk, so `_aliases`
+never becomes an entity itself.
+
+**Adding an alias at runtime** — works for both leaf and branch nodes, and the target may itself be
+given as an alias:
+
+```python
+h = EntityHierarchy()
+h.add_alias("EMAIL_ADDRESS", "ELECTRONIC_MAIL")   # leaf
+h.canonicalize("ELECTRONIC_MAIL")                 # -> 'EMAIL_ADDRESS'
+
+h.add_alias("LOCATION", "GEOGRAPHIC_LOCATION")    # branch -> stored under _aliases
+h.add_alias("LOC", "LOCALITY")                    # target given as an alias
+h.canonicalize("LOCALITY")                        # -> 'LOCATION'
+```
+
+`add_alias()` raises `ValueError` if the alias is already claimed by a descendant of the target — branch
+aliases are applied before the descent into their own subtree, so a descendant would win and the alias
+would never resolve. The hierarchy is left unchanged in that case. Declaring such a collision statically
+in `definitions.py` logs a warning at construction time.
+
+**Looking up an alias** — `canonicalize()`, `to_branch()` and `get_depth()` all accept raw aliases:
+
+```python
+h.canonicalize("LOC")   # -> 'LOCATION'
+h.to_branch("LOC")      # -> 'LOCATION'
+h.get_depth("LOC")      # -> 2
+```
+
+Note that aliases are not canonical entities: `LOC` does not appear in `all_canonical_entities`, and it
+cannot be used as a `map()` *target*.
 
 ## The canonical vocabulary
 
@@ -112,10 +171,9 @@ When you call `mapper.analyze(df)`, the mapper checks for problems that could si
 | Type | Severity | Meaning |
 |------|----------|---------|
 | `UNRESOLVED` | ERROR | Label could not be matched — blocks `get_mapped_results_dataframe()` |
-| `COLLISION_AMBIGUOUS` | WARNING | Depth-2 label maps to multiple depth-3 entities — blocks extraction |
 | `COLLISION_CROSS_BRANCH` | WARNING | Label maps across hierarchy branches — blocks extraction |
 | `PREDICTION_ONLY` | WARNING | Label only in predictions, not dataset — blocks extraction |
-| `COLLISION_TRIVIAL` | INFO | Auto-fixed: descendant collapsed to single ancestor |
+| `COLLISION_SAME_BRANCH` | INFO | Label and annotation share a branch at different depths — handled by hierarchical evaluation |
 | `DATASET_ONLY` | INFO | Label only in dataset annotations (model never predicts it) |
 
 > **Warning**: `get_mapped_results_dataframe()` raises `IncompleteMapping` if any WARNING or ERROR issues remain. INFO issues are non-blocking.
@@ -206,5 +264,5 @@ would have changed the canonical depth if analyzed alone. It's projected onto th
 
 **This is intentional.** The dataset annotations define the ground truth, so the canonical surface is
 anchored to the first model's dataset. If model B has labels that don't fit the surface, they appear
-as `COLLISION_AMBIGUOUS` or `PREDICTION_ONLY` issues — resolve them with `map()` before extracting
+as `COLLISION_CROSS_BRANCH` or `PREDICTION_ONLY` issues — resolve them with `map()` before extracting
 results.

--- a/docs/mapping_scenarios.md
+++ b/docs/mapping_scenarios.md
@@ -32,9 +32,9 @@ The model emits thousands of fine-grained labels; the dataset uses ≤10 broad c
 
 **Real example (Notebook 5):** The OpenMed HuggingFace model predicts `PERSON`, `LOCATION`, `ORGANIZATION`, etc., while the synth dataset labels `city`, `country`, `street_address`, `state`, `county`, `coordinate`, `postcode` as separate entities.
 
-**Issue type produced:** `COLLISION_AMBIGUOUS` (WARNING) — blocking. When a depth-2 ancestor like `LOCATION` is seen in predictions but the canonical surface is at depth 3 (computed by majority vote from the dataset annotations), the mapper can't determine which depth-3 entity to project onto. The user must call `map({'LOCATION': 'GEO'})` (or another appropriate target) to resolve.
+**Issue type produced:** `COLLISION_SAME_BRANCH` (INFO) — non-blocking. When a depth-2 ancestor like `LOCATION` is seen in predictions but the canonical surface is at depth 3 (computed by majority vote from the dataset annotations), the label and its co-occurring annotations sit on the same branch at different depths. Hierarchical evaluation handles this automatically by scoring at the branch level; no `map()` call is required. Use `map({'LOCATION': 'GEO'})` only if you want to force a specific depth-3 target.
 
-**Projection rules in action:** If instead the dataset uses depth-2 labels and the canonical surface locks at depth 2, then fine-grained model labels like `STREET_ADDRESS` auto-collapse to `LOCATION` as `COLLISION_TRIVIAL` (INFO, non-blocking).
+**Projection rules in action:** If instead the dataset uses depth-2 labels and the canonical surface locks at depth 2, then fine-grained model labels like `STREET_ADDRESS` auto-collapse to `LOCATION` — also reported as `COLLISION_SAME_BRANCH` (INFO, non-blocking).
 
 ---
 
@@ -112,7 +112,7 @@ The same string alias appears under multiple canonical entities in the hierarchy
 
 **Issue types produced:**
 - `COLLISION_CROSS_BRANCH` (WARNING) — blocking. Raised when a label resolves to a canonical entity that has co-occurring labels on the same tokens mapping to a different hierarchy branch. Must be resolved with `map()` before extracting results.
-- `COLLISION_AMBIGUOUS` (WARNING) — blocking. Raised when a depth-2 ancestor maps to multiple depth-3 entities on the canonical surface (the top co-occurring candidate is shown in `overlap_counts`). Use `map({'LABEL': 'CANONICAL'})` to pick the right one.
+- `COLLISION_SAME_BRANCH` (INFO) — non-blocking. Raised when a label co-occurs with annotations on the same branch at a different depth (e.g. prediction `PERSON` vs annotation `NAME`). Handled automatically by hierarchical evaluation; use `map({'LABEL': 'CANONICAL'})` only to force a specific target.
 
 ---
 
@@ -166,7 +166,7 @@ The dataset and model operate at different hierarchy depths, producing ancestor�
 
 **Real example (Notebook 5):** Dataset labels `city`, `street_address`, `postcode` (depth 3), model predicts `LOCATION` (depth 2).
 
-**How the new API handles this:** The canonical depth is computed automatically by majority vote from the dataset annotations. If the dataset is predominantly depth-3, the canonical surface is depth-3 and depth-2 model predictions trigger `COLLISION_AMBIGUOUS` (WARNING). Resolve with `map({'LOCATION': 'GEO'})` to pick the right depth-3 target.
+**How the new API handles this:** The canonical depth is computed automatically by majority vote from the dataset annotations. If the dataset is predominantly depth-3, the canonical surface is depth-3 and depth-2 model predictions are reported as `COLLISION_SAME_BRANCH` (INFO) and scored at the branch level by hierarchical evaluation. Use `map({'LOCATION': 'GEO'})` only to force a specific depth-3 target.
 
 ---
 

--- a/docs/mapping_scenarios.md
+++ b/docs/mapping_scenarios.md
@@ -32,7 +32,7 @@ The model emits thousands of fine-grained labels; the dataset uses ≤10 broad c
 
 **Real example (Notebook 5):** The OpenMed HuggingFace model predicts `PERSON`, `LOCATION`, `ORGANIZATION`, etc., while the synth dataset labels `city`, `country`, `street_address`, `state`, `county`, `coordinate`, `postcode` as separate entities.
 
-**Issue type produced:** `COLLISION_AMBIGUOUS` (WARNING) — blocking. When a depth-2 ancestor like `LOCATION` is seen in predictions but the canonical surface is at depth 3 (computed by majority vote from the dataset annotations), the mapper can't determine which depth-3 entity to project onto. The user must call `map({'LOCATION': 'LOC'})` (or another appropriate target) to resolve.
+**Issue type produced:** `COLLISION_AMBIGUOUS` (WARNING) — blocking. When a depth-2 ancestor like `LOCATION` is seen in predictions but the canonical surface is at depth 3 (computed by majority vote from the dataset annotations), the mapper can't determine which depth-3 entity to project onto. The user must call `map({'LOCATION': 'GEO'})` (or another appropriate target) to resolve.
 
 **Projection rules in action:** If instead the dataset uses depth-2 labels and the canonical surface locks at depth 2, then fine-grained model labels like `STREET_ADDRESS` auto-collapse to `LOCATION` as `COLLISION_TRIVIAL` (INFO, non-blocking).
 
@@ -166,7 +166,7 @@ The dataset and model operate at different hierarchy depths, producing ancestor�
 
 **Real example (Notebook 5):** Dataset labels `city`, `street_address`, `postcode` (depth 3), model predicts `LOCATION` (depth 2).
 
-**How the new API handles this:** The canonical depth is computed automatically by majority vote from the dataset annotations. If the dataset is predominantly depth-3, the canonical surface is depth-3 and depth-2 model predictions trigger `COLLISION_AMBIGUOUS` (WARNING). Resolve with `map({'LOCATION': 'LOC'})` to pick the right depth-3 target.
+**How the new API handles this:** The canonical depth is computed automatically by majority vote from the dataset annotations. If the dataset is predominantly depth-3, the canonical surface is depth-3 and depth-2 model predictions trigger `COLLISION_AMBIGUOUS` (WARNING). Resolve with `map({'LOCATION': 'GEO'})` to pick the right depth-3 target.
 
 ---
 

--- a/presidio_evaluator/entity_mapping/definitions.py
+++ b/presidio_evaluator/entity_mapping/definitions.py
@@ -11,6 +11,7 @@
 HIERARCHY: dict = {
     "PII": {
         "PERSON": {
+            "_aliases": ["PER"],
             "NAME": {
                 "FIRST_NAME": [
                     "FIRSTNAME",
@@ -37,7 +38,6 @@ HIERARCHY: dict = {
                     "NAME_MEDICAL_PROFESSIONAL",
                 ],
                 "MAIDEN_NAME": [],
-                "PER": [],
             },
             "PREFIX": [],
             "SUFFIX": [],

--- a/presidio_evaluator/entity_mapping/definitions.py
+++ b/presidio_evaluator/entity_mapping/definitions.py
@@ -87,6 +87,7 @@ HIERARCHY: dict = {
             "SOCIAL_HANDLE": ["QQ"],  # QQ: Chinese messaging platform ID
         },
         "LOCATION": {
+            "_aliases": ["LOC"],
             "ADDRESS": {
                 "STREET_ADDRESS": [
                     "STREET",
@@ -129,10 +130,10 @@ HIERARCHY: dict = {
             ],
             "LOCATION_OTHER": ["LOCATION-OTHER", "ORDINALDIRECTION"],
             "GPE": ["GLOBAL_POLITICAL_ENTITY"],
-            "LOC": [],
             "GEO": [],
         },
         "ORGANIZATION": {
+            "_aliases": ["ORG"],
             "COMPANY": [
                 "COMPANYNAME",
                 "COMPANY_ID",
@@ -148,7 +149,6 @@ HIERARCHY: dict = {
                 "HOSPITAL_NAME",
             ],
             "OTHER_ORG": [],
-            "ORG": [],
         },
         "EMPLOYMENT": {
             "JOB_TITLE": [

--- a/presidio_evaluator/entity_mapping/hierarchy.py
+++ b/presidio_evaluator/entity_mapping/hierarchy.py
@@ -5,6 +5,7 @@
 
 import copy
 import difflib
+import logging
 import re
 
 from presidio_evaluator.entity_mapping.definitions import (
@@ -19,6 +20,8 @@ from presidio_evaluator.entity_mapping.definitions import (
 
 _BIO_PREFIX_RE = re.compile(r"^[BIOELSU]-(.+)$", re.IGNORECASE)
 _BIO_SUFFIX_RE = re.compile(r"^(.+)-[BIOELSU]$", re.IGNORECASE)
+
+logger = logging.getLogger(__name__)
 
 # Reserved key that lets a BRANCH (non-leaf) node declare raw aliases, e.g.
 #   "LOCATION": {"_aliases": ["LOC"], "ADDRESS": {...}, ...}
@@ -97,12 +100,12 @@ class EntityHierarchy:
         return branch
 
     def get_depth(self, entity: str) -> int:
-        """Return the depth of a canonical entity in the hierarchy tree.
+        """Return the depth of an entity in the hierarchy tree.
 
         Depth is defined as the length of the ancestor path:
         PII=1, PERSON=2, NAME=3, FIRST_NAME=4.
 
-        :param entity: A canonical entity name.
+        :param entity: A canonical entity name, or any raw alias of one.
         :return: depth (int >= 1).
         :raises EntityNotMappedError: if entity is not found.
         """
@@ -115,7 +118,7 @@ class EntityHierarchy:
                 branch = self.canonical_to_branch.get(canonical)
         if branch is None:
             raise EntityNotMappedError(
-                f"Canonical entity {entity!r} has no branch in hierarchy"
+                f"Entity {entity!r} has no branch in hierarchy"
             )
         return len(branch)
 
@@ -136,16 +139,16 @@ class EntityHierarchy:
         parent_dict, key = found
         value = parent_dict[key]
         if isinstance(value, list):
-            if alias not in value:
-                value.append(alias)
             added_to = value
         else:
             # Branch (non-leaf) node: record the alias under the reserved key so
             # it maps to this branch, instead of creating a spurious child leaf.
-            aliases = value.setdefault(BRANCH_ALIASES_KEY, [])
-            if alias not in aliases:
-                aliases.append(alias)
-            added_to = aliases
+            added_to = value.setdefault(BRANCH_ALIASES_KEY, [])
+        # Track whether THIS call appended, so a rollback never deletes an alias
+        # that was already there (e.g. re-adding an alias the target already owns).
+        appended = alias not in added_to
+        if appended:
+            added_to.append(alias)
         self._rebuild()
 
         # A branch alias is applied before the recursive descent into its own
@@ -159,18 +162,11 @@ class EntityHierarchy:
         expected = self.raw_to_canonical.get(self.normalize(key))
         resolved = self.raw_to_canonical.get(self.normalize(alias))
         if resolved != expected:
-            added_to.remove(alias)
-            if not added_to and added_to is not value:
-                value.pop(BRANCH_ALIASES_KEY, None)
-            self._rebuild()
-            raise ValueError(
-                f"Alias {alias!r} already resolves to {resolved!r}, "
-                f"so it cannot be added to {key!r}",
-            )
-            added_to.remove(alias)
-            if not added_to and added_to is not value:
-                value.pop(BRANCH_ALIASES_KEY, None)
-            self._rebuild()
+            if appended:
+                added_to.remove(alias)
+                if not added_to and added_to is not value:
+                    value.pop(BRANCH_ALIASES_KEY, None)
+                self._rebuild()
             raise ValueError(
                 f"Alias {alias!r} already resolves to {resolved!r}, "
                 f"so it cannot be added to {key!r}",
@@ -302,6 +298,39 @@ class EntityHierarchy:
             self.hierarchy,
             self.canonical_depth,
         )
+        self._warn_on_shadowed_branch_aliases()
+
+    def _warn_on_shadowed_branch_aliases(self) -> None:
+        """Warn about branch aliases that a descendant silently overrides.
+
+        Branch aliases are written into the lookup before the recursive descent
+        into their own subtree, so a descendant with the same normalized name
+        wins. `add_alias()` rejects that at call time, but a collision baked
+        into the hierarchy definition would otherwise pass unnoticed.
+        """
+        for branch_key, alias in self._collect_branch_aliases(self.hierarchy):
+            expected = self.raw_to_canonical.get(self.normalize(branch_key))
+            resolved = self.raw_to_canonical.get(self.normalize(alias))
+            if expected is not None and resolved != expected:
+                logger.warning(
+                    "Branch alias %r on %r is shadowed by %r and will never "
+                    "resolve to %r.",
+                    alias,
+                    branch_key,
+                    resolved,
+                    expected,
+                )
+
+    @staticmethod
+    def _collect_branch_aliases(node: dict) -> list[tuple[str, str]]:
+        """Return (branch_name, alias) for every branch-level alias in the tree."""
+        found: list[tuple[str, str]] = []
+        for key, value in node.items():
+            if key == BRANCH_ALIASES_KEY or not isinstance(value, dict):
+                continue
+            found.extend((key, a) for a in value.get(BRANCH_ALIASES_KEY, []))
+            found.extend(EntityHierarchy._collect_branch_aliases(value))
+        return found
 
     def _resolve_remainder(self, remainder: str, threshold: float) -> str:
         """Canonicalize the document-type portion of a country-prefixed label, falling back to NATIONAL_ID."""

--- a/presidio_evaluator/entity_mapping/hierarchy.py
+++ b/presidio_evaluator/entity_mapping/hierarchy.py
@@ -20,6 +20,13 @@ from presidio_evaluator.entity_mapping.definitions import (
 _BIO_PREFIX_RE = re.compile(r"^[BIOELSU]-(.+)$", re.IGNORECASE)
 _BIO_SUFFIX_RE = re.compile(r"^(.+)-[BIOELSU]$", re.IGNORECASE)
 
+# Reserved key that lets a BRANCH (non-leaf) node declare raw aliases, e.g.
+#   "LOCATION": {"_aliases": ["LOC"], "ADDRESS": {...}, ...}
+# Leaf nodes already carry their aliases as a list value; branch nodes are dicts
+# and previously had nowhere to declare synonyms. This key is skipped by every
+# tree-walk so it never becomes a canonical entity itself.
+BRANCH_ALIASES_KEY = "_aliases"
+
 
 class EntityHierarchy:
     """
@@ -101,14 +108,29 @@ class EntityHierarchy:
         """
         branch = self.canonical_to_branch.get(entity)
         if branch is None:
+            # Accept raw aliases (including branch-level ones such as "LOC")
+            # by resolving them to their canonical name first.
+            canonical = self.raw_to_canonical.get(self.normalize(entity))
+            if canonical is not None:
+                branch = self.canonical_to_branch.get(canonical)
+        if branch is None:
             raise EntityNotMappedError(
                 f"Canonical entity {entity!r} has no branch in hierarchy"
             )
         return len(branch)
 
     def add_alias(self, entity_name: str, alias: str) -> None:
-        """Add a raw alias for an existing entity."""
+        """Add a raw alias for an existing entity (leaf or branch).
+
+        *entity_name* may be a canonical name or any raw alias of one.
+        """
         found = self._find_node(entity_name)
+        if found is None:
+            # Fall back to alias resolution so e.g. add_alias("LOC", x) works
+            # even though "LOC" is itself an alias of the LOCATION branch.
+            canonical = self.raw_to_canonical.get(self.normalize(entity_name))
+            if canonical is not None:
+                found = self._find_node(canonical)
         if found is None:
             raise KeyError(f"Entity {entity_name!r} not found in hierarchy")
         parent_dict, key = found
@@ -116,9 +138,43 @@ class EntityHierarchy:
         if isinstance(value, list):
             if alias not in value:
                 value.append(alias)
+            added_to = value
         else:
-            value[alias] = []
+            # Branch (non-leaf) node: record the alias under the reserved key so
+            # it maps to this branch, instead of creating a spurious child leaf.
+            aliases = value.setdefault(BRANCH_ALIASES_KEY, [])
+            if alias not in aliases:
+                aliases.append(alias)
+            added_to = aliases
         self._rebuild()
+
+        # A branch alias is applied before the recursive descent into its own
+        # subtree, so a descendant with the same normalized name wins. Rather
+        # than persist an alias that silently never resolves, roll back and say
+        # so — the caller's intent could not be honoured.
+        #
+        # The alias is correct when it resolves wherever the TARGET resolves:
+        # for a node below canonical_depth that is the canonical ancestor, not
+        # the node's own name.
+        expected = self.raw_to_canonical.get(self.normalize(key))
+        resolved = self.raw_to_canonical.get(self.normalize(alias))
+        if resolved != expected:
+            added_to.remove(alias)
+            if not added_to and added_to is not value:
+                value.pop(BRANCH_ALIASES_KEY, None)
+            self._rebuild()
+            raise ValueError(
+                f"Alias {alias!r} already resolves to {resolved!r}, "
+                f"so it cannot be added to {key!r}",
+            )
+            added_to.remove(alias)
+            if not added_to and added_to is not value:
+                value.pop(BRANCH_ALIASES_KEY, None)
+            self._rebuild()
+            raise ValueError(
+                f"Alias {alias!r} already resolves to {resolved!r}, "
+                f"so it cannot be added to {key!r}",
+            )
 
     @staticmethod
     def _strip_bio(label: str) -> str:
@@ -139,6 +195,10 @@ class EntityHierarchy:
             items.extend(value)
         elif isinstance(value, dict):
             for k, v in value.items():
+                if k == BRANCH_ALIASES_KEY:
+                    # Collect the aliases themselves, never the reserved key name.
+                    items.extend(v)
+                    continue
                 items.append(k)
                 items.extend(EntityHierarchy._collect_all_raw(v))
         return items
@@ -152,6 +212,8 @@ class EntityHierarchy:
         """Build a normalized-label → canonical-name lookup dict by walking the hierarchy tree."""
         mapping: dict[str, str] = {}
         for key, value in node.items():
+            if key == BRANCH_ALIASES_KEY:
+                continue  # reserved: branch aliases, applied by the parent below
             if depth >= canonical_depth:
                 mapping[EntityHierarchy.normalize(key)] = key
                 for alias in EntityHierarchy._collect_all_raw(value):
@@ -162,6 +224,9 @@ class EntityHierarchy:
                     mapping[EntityHierarchy.normalize(alias)] = key
             elif isinstance(value, dict):
                 mapping[EntityHierarchy.normalize(key)] = key
+                # Branch-level aliases: raw synonyms of this non-leaf node.
+                for alias in value.get(BRANCH_ALIASES_KEY, []):
+                    mapping[EntityHierarchy.normalize(alias)] = key
                 mapping.update(
                     EntityHierarchy._build_alias_map(value, canonical_depth, depth + 1),
                 )
@@ -176,6 +241,8 @@ class EntityHierarchy:
         """Collect the names of all canonical-depth leaf nodes from the hierarchy tree."""
         result: list[str] = []
         for key, value in node.items():
+            if key == BRANCH_ALIASES_KEY:
+                continue  # reserved: not a canonical entity
             if depth >= canonical_depth:
                 result.append(key)
             elif isinstance(value, list):
@@ -202,6 +269,8 @@ class EntityHierarchy:
             current_path = []
         result: dict[str, list[str]] = {}
         for key, value in node.items():
+            if key == BRANCH_ALIASES_KEY:
+                continue  # reserved: not a canonical entity
             path = current_path + [key]
             if depth >= canonical_depth:
                 result[key] = path
@@ -317,6 +386,14 @@ class EntityHierarchy:
         if label is None or label == "O":
             return "O"
         branch_path = self.canonical_to_branch.get(label)
+        if branch_path is None:
+            # Not a canonical name — it may be a raw alias (leaf or branch
+            # level, e.g. "LOC"). Resolve it before giving up, so callers
+            # feeding raw dataset labels get the right branch instead of a
+            # silent pass-through into a different bucket.
+            canonical = self.raw_to_canonical.get(self.normalize(label))
+            if canonical is not None:
+                branch_path = self.canonical_to_branch.get(canonical)
         if branch_path is None or len(branch_path) < 2:
             return label
         return branch_path[1]
@@ -329,6 +406,11 @@ class EntityHierarchy:
         """Return (parent_dict, key) for the first node matching name in the hierarchy tree, or None."""
         if tree is None:
             tree = self.hierarchy
+        if name == BRANCH_ALIASES_KEY:
+            # Reserved key: it is not an entity, so it must not be addressable
+            # as one (otherwise add_alias("_aliases", x) would silently attach x
+            # to whichever branch happens to be found first).
+            return None
         for key, value in tree.items():
             if key == name:
                 return (tree, key)

--- a/tests/entity_mapping/test_entity_hierarchy.py
+++ b/tests/entity_mapping/test_entity_hierarchy.py
@@ -5,6 +5,7 @@ from presidio_evaluator.entity_mapping import (
     EntityHierarchy,
     EntityNotMappedError,
 )
+from presidio_evaluator.entity_mapping.hierarchy import BRANCH_ALIASES_KEY
 
 _h = EntityHierarchy()
 
@@ -58,8 +59,8 @@ class TestCanonicalizeExplicitAliases:
         assert _h.canonicalize("LOCATION") == "LOCATION"
 
     def test_organization_alias(self):
-        # ORG is its own canonical leaf node
-        assert _h.canonicalize("ORG") == "ORG"
+        # ORG is a branch-level alias of ORGANIZATION (see BRANCH_ALIASES_KEY)
+        assert _h.canonicalize("ORG") == "ORGANIZATION"
 
 
 # ---------------------------------------------------------------------------
@@ -242,9 +243,10 @@ class TestGetBranch:
         assert _h.get_branch("LOCATION") == ["PII", "LOCATION"]
 
     def test_organization(self):
+        # ORG is now a branch-level alias of ORGANIZATION
         branch = _h.get_branch("ORG")
         assert branch is not None
-        assert branch[-1] == "ORG"
+        assert branch[-1] == "ORGANIZATION"
 
 
 # ---------------------------------------------------------------------------
@@ -445,6 +447,15 @@ class TestEntityHierarchyClass:
         with pytest.raises(KeyError):
             h.add_alias("NONEXISTENT_ENTITY", "SOME_ALIAS")
 
+    def test_add_alias_reserved_key_raises(self):
+        # The reserved branch-alias key is not an entity, so it must not be
+        # addressable as one — otherwise the alias would be silently attached
+        # to whichever branch happens to be found first in the tree walk.
+        h = EntityHierarchy()
+        with pytest.raises(KeyError):
+            h.add_alias(BRANCH_ALIASES_KEY, "SOME_ALIAS")
+        assert h.normalize("SOME_ALIAS") not in h.raw_to_canonical
+
     def test_add_alias_rebuilds_lookup(self):
         h = EntityHierarchy()
         h.add_alias("SSN", "MY_SSN")
@@ -495,3 +506,117 @@ class TestCanonicalizeWithFuzzy:
     def test_get_branch_after_fuzzy_country(self):
         canonical = self.h.canonicalize("ARGENTENIAN_TAX_ID")
         assert self.h.get_branch(canonical) == ["PII", "GOVERNMENT_ID", "TAX_ID"]
+
+
+# ---------------------------------------------------------------------------
+# Branch-level aliases (BRANCH_ALIASES_KEY)
+# ---------------------------------------------------------------------------
+
+
+class TestBranchAliases:
+    """Branch (non-leaf) nodes can declare raw aliases via the reserved
+    `_aliases` key; those resolve to the branch and never become entities."""
+
+    def setup_method(self):
+        self.h = EntityHierarchy()
+
+    def test_loc_resolves_to_location(self):
+        assert self.h.canonicalize("LOC") == "LOCATION"
+
+    def test_org_resolves_to_organization(self):
+        assert self.h.canonicalize("ORG") == "ORGANIZATION"
+
+    def test_loc_and_location_share_one_leaf(self):
+        assert self.h.canonicalize("LOC") == self.h.canonicalize("LOCATION")
+
+    def test_org_and_organization_share_one_leaf(self):
+        assert self.h.canonicalize("ORG") == self.h.canonicalize("ORGANIZATION")
+
+    def test_branch_alias_gets_branch_path(self):
+        assert self.h.get_branch("LOC") == ["PII", "LOCATION"]
+        assert self.h.get_branch("ORG") == ["PII", "ORGANIZATION"]
+
+    def test_reserved_key_is_not_a_canonical_entity(self):
+        assert "_aliases" not in self.h.all_canonical_entities
+        assert "_aliases" not in self.h.canonical_to_branch
+
+    def test_unrelated_leaves_unchanged(self):
+        assert self.h.canonicalize("EMAIL") == "EMAIL_ADDRESS"
+        assert self.h.canonicalize("GPE") == "GPE"
+        assert self.h.canonicalize("GEO") == "GEO"
+
+    def test_add_alias_on_branch_node(self):
+        h = EntityHierarchy()
+        h.add_alias("LOCATION", "GEOGRAPHIC_LOCATION")
+        assert h.canonicalize("GEOGRAPHIC_LOCATION") == "LOCATION"
+        # the alias must not leak in as a standalone canonical entity
+        assert "GEOGRAPHIC_LOCATION" not in h.all_canonical_entities
+
+    def test_add_alias_on_branch_is_idempotent(self):
+        h = EntityHierarchy()
+        h.add_alias("ORGANIZATION", "FIRM")
+        h.add_alias("ORGANIZATION", "FIRM")
+        assert h.canonicalize("FIRM") == "ORGANIZATION"
+
+    def test_reserved_key_never_leaks_at_deep_nodes(self):
+        # _aliases on a canonical-depth dict node must not surface the literal
+        # "_aliases" string as a resolvable alias.
+        import copy
+
+        from presidio_evaluator.entity_mapping.hierarchy import BRANCH_ALIASES_KEY
+
+        h = EntityHierarchy()
+        hier = copy.deepcopy(h.hierarchy)
+        hier["PII"]["DEMOGRAPHIC"]["PHYSICAL_DESCRIPTOR"][BRANCH_ALIASES_KEY] = [
+            "BODY_DESC"
+        ]
+        h2 = EntityHierarchy(hierarchy=hier)
+        assert h2.normalize(BRANCH_ALIASES_KEY) not in h2.raw_to_canonical
+        assert h2.canonicalize("BODY_DESC") == "PHYSICAL_DESCRIPTOR"
+
+    # ── behavior change: LOC/ORG are aliases, no longer canonical entities ──
+
+    def test_loc_and_org_are_no_longer_canonical_entities(self):
+        # They were empty leaf nodes before; they are branch aliases now.
+        assert "LOC" not in self.h.all_canonical_entities
+        assert "ORG" not in self.h.all_canonical_entities
+        assert "LOC" not in self.h.canonical_to_branch
+        assert "ORG" not in self.h.canonical_to_branch
+
+    def test_to_branch_resolves_branch_aliases(self):
+        # Regression guard: to_branch must not silently pass a raw alias
+        # through into a different bucket.
+        assert self.h.to_branch("LOC") == "LOCATION"
+        assert self.h.to_branch("ORG") == "ORGANIZATION"
+
+    def test_to_branch_resolves_leaf_aliases(self):
+        assert self.h.to_branch("COMPANYNAME") == "ORGANIZATION"
+
+    def test_to_branch_passes_through_unknown_labels(self):
+        assert self.h.to_branch("NOT_AN_ENTITY") == "NOT_AN_ENTITY"
+
+    def test_get_depth_resolves_branch_aliases(self):
+        assert self.h.get_depth("LOC") == self.h.get_depth("LOCATION")
+        assert self.h.get_depth("ORG") == self.h.get_depth("ORGANIZATION")
+
+    def test_add_alias_accepts_an_alias_as_the_subject(self):
+        h = EntityHierarchy()
+        h.add_alias("LOC", "LOCALITY")
+        assert h.canonicalize("LOCALITY") == "LOCATION"
+
+    def test_branch_alias_at_non_default_canonical_depth(self):
+        # CanonicalMapper builds EntityHierarchy(canonical_depth=10).
+        for depth in (2, 3, 4, 10):
+            h = EntityHierarchy(canonical_depth=depth)
+            assert h.canonicalize("LOC") == "LOCATION", f"depth={depth}"
+            assert h.canonicalize("ORG") == "ORGANIZATION", f"depth={depth}"
+            assert BRANCH_ALIASES_KEY not in h.all_canonical_entities
+
+    def test_branch_alias_shadowed_by_descendant_is_reported(self):
+        # "CITY" already resolves to ADDRESS; adding it as a LOCATION branch
+        # alias cannot win, and must not silently pretend to have worked.
+        h = EntityHierarchy()
+        before = h.canonicalize("CITY")
+        with pytest.raises(ValueError, match="already resolves"):
+            h.add_alias("LOCATION", "CITY")
+        assert h.canonicalize("CITY") == before

--- a/tests/entity_mapping/test_entity_hierarchy.py
+++ b/tests/entity_mapping/test_entity_hierarchy.py
@@ -620,3 +620,39 @@ class TestBranchAliases:
         with pytest.raises(ValueError, match="already resolves"):
             h.add_alias("LOCATION", "CITY")
         assert h.canonicalize("CITY") == before
+
+    def test_per_resolves_to_person(self):
+        assert self.h.canonicalize("PER") == "PERSON"
+        assert self.h.to_branch("PER") == "PERSON"
+        assert "PER" not in self.h.all_canonical_entities
+
+    def test_failed_add_alias_keeps_existing_alias(self):
+        # "VRN" is already an alias of both LICENSE_PLATE_NUMBER and
+        # LICENSE_PLATE. Re-adding it to the former must raise WITHOUT
+        # stripping the alias it already owns.
+        h = EntityHierarchy()
+        before = h.canonicalize("VRN")
+        with pytest.raises(ValueError, match="already resolves"):
+            h.add_alias("LICENSE_PLATE_NUMBER", "VRN")
+        assert h.canonicalize("VRN") == before
+        node = h._find_node("LICENSE_PLATE_NUMBER")
+        assert "VRN" in node[0][node[1]]
+
+    def test_statically_shadowed_branch_alias_warns(self, caplog):
+        import copy
+        import logging
+
+        hier = copy.deepcopy(HIERARCHY)
+        # "CITY" already resolves to ADDRESS, so this branch alias is dead.
+        hier["PII"]["LOCATION"][BRANCH_ALIASES_KEY] = ["LOC", "CITY"]
+        with caplog.at_level(logging.WARNING):
+            EntityHierarchy(hierarchy=hier)
+        assert any("shadowed" in r.message for r in caplog.records)
+
+    def test_clean_hierarchy_emits_no_shadow_warning(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            EntityHierarchy()
+        assert not [r for r in caplog.records if "shadowed" in r.message]
+


### PR DESCRIPTION
## Problem

Leaf nodes in the hierarchy carry alias lists (`"EMAIL_ADDRESS": ["EMAIL", ...]`), but branch (non-leaf) nodes are dicts with nowhere to declare synonyms. So coarse dataset labels like TAB's `LOC`/`ORG` existed as separate empty leaves and could only ever match a model's `LOCATION`/`ORGANIZATION` at the **branch** level, never **exact** — understating exact-level scores for every model on such a corpus.

## Fix

Add a reserved `_aliases` key so a branch can declare raw aliases:

```python
"LOCATION": {"_aliases": ["LOC"], "ADDRESS": {...}, ...}
```

Every tree-walk skips the key, so it never becomes a canonical entity. `LOC`/`ORG` move onto the `LOCATION`/`ORGANIZATION` branches.

Once they stop being canonical entities, the canonical-name lookups have to learn about aliases:

- `to_branch()` / `get_depth()` now resolve aliases first. Without this `to_branch("LOC")` would silently return `"LOC"` instead of `"LOCATION"` — projecting into a *different branch* rather than failing. This also makes existing leaf aliases (`COMPANYNAME`, `QQ`) work for the first time.
- `add_alias()` accepts an alias as its subject, so `add_alias("LOC", ...)` works.
- `_find_node()` no longer matches the reserved key, which let `add_alias("_aliases", x)` attach `x` to whichever branch the walk hit first.
- `add_alias()` raises `ValueError` instead of silently no-opping when a descendant already claims the name (branch aliases are applied before the descent into their own subtree, so the descendant wins). The hierarchy is rolled back.

## Breaking

`LOC`/`ORG` are no longer canonical entities:

- `canonicalize("LOC") == "LOCATION"` (was `"LOC"`); absent from `all_canonical_entities` and `canonical_to_branch`.
- `get_depth("LOC") == 2` (was `3`) — `LOC` now denotes the depth-2 branch.
- `CanonicalMapper.map()` no longer accepts them as resolution *targets*; the mapping is also no longer needed. Two `docs/mapping_scenarios.md` examples updated.
- `to_branch("LOC")` still returns `"LOCATION"`, unchanged.

## Tests

`TestBranchAliases` covers resolution, branch paths, reserved-key non-leakage at deep nodes, alias-as-subject, the `to_branch`/`get_depth` regression guards, non-default `canonical_depth` (2/3/4/10 — `CanonicalMapper` builds at depth 10), and the collision rollback.

**724 passed, 2 skipped**, ruff clean.
