### PR TITLE
docs: fix notebook list, move data-generation doc, link to Presidio

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ It also includes a fake data generator that creates synthetic sentences based on
 
 
 ### Using notebooks
-The easiest way to get started is by reviewing the notebooks. 
+The easiest way to get started is by reviewing the notebooks.
+
 - [Notebook 1](notebooks/1_Generate_data.ipynb): Shows how to use the PII data generator.
 - [Notebook 2](notebooks/2_PII_EDA.ipynb): Shows a simple analysis of the PII dataset.
 - [Notebook 3](notebooks/3_Split_by_pattern_number.ipynb): Provides tools to split the dataset into train/test/validation sets while avoiding leakage due to the same pattern appearing in multiple folds (only applicable for synthetically generated data).
@@ -67,13 +68,13 @@ Note that some dependencies (such as Flair and Stanza) are no longer supported. 
 
 ## 1. Data generation
 
-See [Data Generator README](presidio_evaluator/data_generator/README.md) for more details.
+See the [Data Generation docs](docs/data_generation.md) for more details.
 
 The data generation process takes a file with templates, e.g. `My name is {{name}}`. 
 Then, it creates new synthetic sentences by sampling templates and PII values. 
 Furthermore, it tokenizes the data, creates tags (either IO/BIO/BILUO) and spans for the newly created samples.
 
-- For information on data generation/augmentation, see the data generator [README](presidio_evaluator/data_generator/README.md).
+- For information on data generation/augmentation, see the [Data Generation docs](docs/data_generation.md).
 - For an example for running the generation process, see [this notebook](notebooks/1_Generate_data.ipynb).
 - For an understanding of the underlying fake PII data used, see this [exploratory data analysis notebook](notebooks/2_PII_EDA.ipynb).
 

--- a/docs/data_generation.md
+++ b/docs/data_generation.md
@@ -1,0 +1,84 @@
+# Data Generation
+
+The `PresidioSentenceFaker` generates sentences from templates (e.g. `my name is {{person}}`) where the placeholders
+are replaced with fake PII entities, along with metadata about the spans (the start and end of each entity) for model training and evaluation.
+
+## Scenarios
+
+There are two main scenarios for using the `PresidioSentenceFaker`:
+
+1. Create a fake dataset for evaluation or training purposes, given a list of predefined templates
+(uses [this file](https://github.com/data-privacy-stack/presidio-research/blob/main/presidio_evaluator/data_generator/raw_data/templates.txt) by default)
+2. Augment an existing labeled dataset with additional fake values.
+
+In both scenarios the process is similar. In scenario 2, the existing dataset is first translated into templates,
+and then scenario 1 is applied.
+
+## Process
+
+This generator heavily relies on the [Faker package](https://www.github.com/joke2k/faker) with a few differences:
+
+1. `PresidioSentenceFaker` returns not only fake text, but also the spans in which fake entities appear in the text.
+2. `Faker` samples each value independently.
+In many cases, we would want to keep the semantic dependency between two values.
+For example, for the template `My name is {{name}} and my email is {{email}}`,
+we would prefer a result which has the name within the email address,
+such as `My name is Mike and my email is mike1243@gmail.com`.
+For this functionality, a new `RecordGenerator` (based on Faker's `Generator` class) is implemented.
+It accepts a dictionary / pandas DataFrame, and favors returning objects from the same record (if possible).
+
+## Example
+
+For a full example, see the [Generate Data notebook](notebooks/1_Generate_data.ipynb).
+
+`PresidioSentenceFaker` provides a high-level interface for using the full power of the `presidio_evaluator`
+package. Its results use the presidio PII entities, not the `Faker` entities.
+It is loaded by default with template strings, and the additional Presidio Entity Providers.
+
+```python
+from presidio_evaluator.data_generator import PresidioSentenceFaker
+
+record_generator = PresidioSentenceFaker(locale='en', lower_case_ratio=0.05)
+fake_records = record_generator.generate_new_fake_sentences(1500)
+
+# Print the spans of the first sample
+print(fake_records[0].fake)
+print(fake_records[0].spans)
+```
+
+The process at a high level is the following:
+
+1. Translate a NER dataset (e.g. CONLL or OntoNotes) into a list of
+templates: `My name is John` -> `My name is [PERSON]`
+2. Construct a `PresidioSentenceFaker` instance by:
+   - Choosing your appropriate locale, e.g. `en_US`
+   - Choosing the lower case ratio
+   - Passing in your list of templates (or default to those provided)
+     - Optionally extend with provided templates accessible via `from presidio_evaluator.data_generator import presidio_templates_file_path`
+   - Passing in any custom entity providers (or default to those provided)
+     - Optionally extend with inbuilt presidio entity providers accessible via `from presidio_evaluator.data_generator import presidio_additional_entity_providers`
+     - Adding a mapping from the output provider entity type to a Presidio recognized entity type where appropriate
+       - e.g. For a `TownProvider` which outputs entity type of `town`, execute `PresidioSentenceFaker.ENTITY_TYPE_MAPPING['town'] = 'GPE'`)
+   - Passing in a DataFrame representing your underlying PII records (or default to those provided)
+     - Optionally extend with inbuilt presidio entity providers accessible via `from presidio_evaluator.data_generator.faker_extensions.datasets import load_fake_person_df`
+   - Adding any additional aliases required by your dataset by adding to `PresidioSentenceFaker.PROVIDER_ALIASES`
+     - e.g. if the entity providers support "name" but your dataset templates contain "person", you can add this alias
+     with `PresidioSentenceFaker.PROVIDER_ALIASES['name'] = 'person'`)
+3. Generate sentences
+4. Split the generated dataset into train/test/validation while making sure
+that samples from the same template would only appear in one set
+5. Adapt datasets for the various models (Spacy, Flair, CRF, sklearn)
+6. Train models
+7. Evaluate using one of the [evaluation notebooks](https://github.com/data-privacy-stack/presidio-research/tree/main/notebooks/models)
+
+Notes:
+
+- For steps 5, 6, 7 see the [home page](index.md).
+
+
+*Copyright notice:*
+
+Fake Name Generator identities by the Fake Name Generator are licensed under a
+Creative Commons Attribution-Share Alike 3.0 United States License.
+Fake Name Generator and the Fake Name Generator logo
+are trademarks of Corban Works, LLC.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,23 +13,24 @@ edit_uri: ""
 # the build script stages and converts them before Zensical runs.
 nav:
   - Home: index.md
-  - Tutorials (notebooks):
+  - Concepts:
+      - Evaluation strategies: 
+        - Home: evaluation.md
+        - Token evaluation: token_evaluation.md
+        - Span evaluation: span_evaluation.md
+        - Span matching strategies: span_matching_strategies.md
+      - Entity Mapping:
+        - Entity hierarchy: entity_hierarchy.md
+        - Why canonical entity mapping: why_canonical_entity_mapping.md
+        - Mapping scenarios: mapping_scenarios.md
+      - Data generation: data_generation.md
+  - Tutorials:
       - Generate data: notebooks/1_Generate_data.ipynb
       - PII dataset EDA: notebooks/2_PII_EDA.ipynb
       - Split by pattern: notebooks/3_Split_by_pattern_number.ipynb
       - Evaluate Presidio Analyzer: notebooks/4_Evaluate_Presidio_Analyzer.ipynb
       - Evaluate a custom Analyzer: notebooks/5_Evaluate_Custom_Presidio_Analyzer.ipynb
       - Interactive entity mapping: notebooks/6_Interactive_Entity_Mapping.ipynb
-  - Data generation: data_generation.md
-  - Concepts:
-      - Evaluation: evaluation.md
-      - Token evaluation: token_evaluation.md
-      - Span evaluation: span_evaluation.md
-      - Span matching strategies: span_matching_strategies.md
-      - Entity hierarchy: entity_hierarchy.md
-      - Why canonical entity mapping: why_canonical_entity_mapping.md
-      - Mapping scenarios: mapping_scenarios.md
-      - Migration guide: migration-guide.md
   - Presidio ↗: https://presidio.dataprivacystack.org
 
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
       - Evaluate Presidio Analyzer: notebooks/4_Evaluate_Presidio_Analyzer.ipynb
       - Evaluate a custom Analyzer: notebooks/5_Evaluate_Custom_Presidio_Analyzer.ipynb
       - Interactive entity mapping: notebooks/6_Interactive_Entity_Mapping.ipynb
+  - Data generation: data_generation.md
   - Concepts:
       - Evaluation: evaluation.md
       - Token evaluation: token_evaluation.md
@@ -29,6 +30,7 @@ nav:
       - Why canonical entity mapping: why_canonical_entity_mapping.md
       - Mapping scenarios: mapping_scenarios.md
       - Migration guide: migration-guide.md
+  - Presidio ↗: https://presidio.dataprivacystack.org
 
 theme:
   name: material

--- a/presidio_evaluator/data_generator/README.md
+++ b/presidio_evaluator/data_generator/README.md
@@ -1,84 +1,9 @@
 # Data Generation
 
-The `PresidioSentenceFaker` generates sentences from templates (e.g. `my name is {{person}}`) where the placeholders
-are replaced with fake PII entities, along with metadata about the spans (the start and end of each entity) for model training and evaluation.
+📖 The data generation documentation now lives in the Presidio-Research docs:
 
-## Scenarios
+- **Online:** <https://presidio-research.dataprivacystack.org/data_generation/>
+- **Source:** [`docs/data_generation.md`](../../docs/data_generation.md)
 
-There are two main scenarios for using the `PresidioSentenceFaker`:
-
-1. Create a fake dataset for evaluation or training purposes, given a list of predefined templates 
-(uses [this file](raw_data/templates.txt) by default)
-2. Augment an existing labeled dataset with additional fake values.
-
-In both scenarios the process is similar. In scenario 2, the existing dataset is first translated into templates, 
-and then scenario 1 is applied.
-
-## Process
-
-This generator heavily relies on the [Faker package](https://www.github.com/joke2k/faker) with a few differences:
-
-1. `PresidioSentenceFaker` returns not only fake text, but also the spans in which fake entities appear in the text.
-2. `Faker` samples each value independently.
-In many cases, we would want to keep the semantic dependency between two values. 
-For example, for the template `My name is {{name}} and my email is {{email}}`, 
-we would prefer a result which has the name within the email address, 
-such as `My name is Mike and my email is mike1243@gmail.com`. 
-For this functionality, a new `RecordGenerator` (based on Faker's `Generator` class) is implemented. 
-It accepts a dictionary / pandas DataFrame, and favors returning objects from the same record (if possible).
-
-## Example
-
-For a full example, see the [Generate Data Notebook](../../notebooks/1_Generate_data.ipynb).
-
-`PresidioSentenceFaker` provides a high-level interface for using the full power of the `presidio_evaluator`
-package. Its results use the presidio PII entities, not the `Faker` entities.
-It is loaded by default with template strings, and the additional Presidio Entity Providers.
-
-```python
-from presidio_evaluator.data_generator import PresidioSentenceFaker
-
-record_generator = PresidioSentenceFaker(locale='en', lower_case_ratio=0.05)
-fake_records = record_generator.generate_new_fake_sentences(1500)
-
-# Print the spans of the first sample
-print(fake_records[0].fake)
-print(fake_records[0].spans)
-```
-
-The process at a high level is the following:
-
-1. Translate a NER dataset (e.g. CONLL or OntoNotes) into a list of
-templates: `My name is John` -> `My name is [PERSON]`
-2. Construct a `PresidioSentenceFaker` instance by:
-   - Choosing your appropriate locale, e.g. `en_US`
-   - Choosing the lower case ratio
-   - Passing in your list of templates (or default to those provided)
-     - Optionally extend with provided templates accessible via `from presidio_evaluator.data_generator import presidio_templates_file_path`
-   - Passing in any custom entity providers (or default to those provided)
-     - Optionally extend with inbuilt presidio entity providers accessible via `from presidio_evaluator.data_generator import presidio_additional_entity_providers`
-     - Adding a mapping from the output provider entity type to a Presidio recognized entity type where appropriate
-       - e.g. For a `TownProvider` which outputs entity type of `town`, execute `PresidioSentenceFaker.ENTITY_TYPE_MAPPING['town'] = 'GPE'`)
-   - Passing in a DataFrame representing your underlying PII records (or default to those provided)
-     - Optionally extend with inbuilt presidio entity providers accessible via `from presidio_evaluator.data_generator.faker_extensions.datasets import load_fake_person_df`
-   - Adding any additional aliases required by your dataset by adding to `PresidioSentenceFaker.PROVIDER_ALIASES`
-     - e.g. if the entity providers support "name" but your dataset templates contain "person", you can add this alias
-     with `PresidioSentenceFaker.PROVIDER_ALIASES['name'] = 'person'`)
-3. Generate sentences
-4. Split the generated dataset into train/test/validation while making sure
-that samples from the same template would only appear in one set
-5. Adapt datasets for the various models (Spacy, Flair, CRF, sklearn)
-6. Train models
-7. Evaluate using one of the [evaluation notebooks](../../notebooks/models)
-
-Notes:
-
-- For steps 5, 6, 7 see the main [README](../../README.md).
-
-
-*Copyright notice:*
-
-Fake Name Generator identities by the Fake Name Generator are licensed under a
-Creative Commons Attribution-Share Alike 3.0 United States License.
-Fake Name Generator and the Fake Name Generator logo
-are trademarks of Corban Works, LLC.
+It covers the `PresidioSentenceFaker` scenarios, the generation process, and a
+full end-to-end example.

--- a/scripts/zensical_build.py
+++ b/scripts/zensical_build.py
@@ -155,9 +155,15 @@ def _absolutise_readme_links(text: str, notebook_rels: set[str]) -> str:
         if url.startswith(("http://", "https://", "//", "mailto:", "#")):
             return match.group(0)
         path, _, frag = url.partition("#")
+        clean_path = path.lstrip("./")
         # Notebook links become on-site pages; leave them for the .ipynb pass.
-        if path.lstrip("./") in notebook_rels:
+        if clean_path in notebook_rels:
             return match.group(0)
+        # Links into docs/ resolve to on-site pages: the docs tree is the site
+        # root, so drop the leading ``docs/`` and keep the link relative.
+        if clean_path.startswith("docs/") and clean_path.endswith(".md"):
+            rel = clean_path[len("docs/") :]
+            return f"{prefix}{rel}" + (f"#{frag}" if frag else "")
         is_image = prefix.startswith("!") or prefix.startswith(("src=",))
         base = GH_RAW if is_image else GH_BLOB
         clean = path.lstrip("./")


### PR DESCRIPTION
Follow-up polish to the docs site (originally #188, re-based cleanly onto `main` after #187 was squash-merged).

## Changes
1. **Notebook list renders correctly** — added the missing blank line before the "Using notebooks" list in `README.md` so Python-Markdown (Zensical) renders it as a bulleted list instead of a run-on paragraph.
2. **Data-generation doc moved into `/docs`** — content moved from `presidio_evaluator/data_generator/README.md` to `docs/data_generation.md` (added to the nav); the in-package file is now a pointer to it, and the main `README.md` links were updated.
3. **Link to Presidio** — external nav entry "Presidio ↗" → https://presidio.dataprivacystack.org.
4. **Build tweak** — `zensical_build.py` keeps the README's `docs/*.md` links on-site instead of absolutising them to GitHub.

Verified locally: `python scripts/zensical_build.py build` → "No issues found".

🤖 Generated with [Claude Code](https://claude.com/claude-code)