### PR TITLE
fix: address review comments left unaddressed on #186

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- **`add_alias()` no longer rejects a valid alias on `LICENSE`** — the rollback guard added alongside branch aliases asked where the *target's name* resolves and compared that to where the new alias landed. Those are the same question for every node except one: the hierarchy declares `LICENSE` both as a canonical leaf under `EMPLOYMENT` and as an alias of `PROFESSIONAL_LICENSE`, so `canonicalize("LICENSE")` is `"PROFESSIONAL_LICENSE"` and a brand-new alias correctly attached to the `LICENSE` leaf looked like a conflict. `add_alias("LICENSE", "PROF_LIC")` raised `ValueError` claiming the alias "already resolves to 'LICENSE'" — describing the mapping the call had itself created one line earlier. The guard now derives the target from the node's path in the tree rather than from a name lookup, so it is unaffected by another node claiming the same name. Verified across all 126 canonical entities: previously 1 rejected a fresh alias, now none do.
+- **`add_alias()` no longer silently steals an alias from another entity** — `add_alias("LOCATION", "EMAIL")` was accepted and quietly re-pointed `EMAIL` from `EMAIL_ADDRESS` to `LOCATION`, invalidating every corpus already annotated with that label. Whether the theft succeeded depended only on dictionary ordering. An alias already resolving somewhere other than the requested target is now rejected before the hierarchy is touched.
+- **A rejected `add_alias()` no longer logs a spurious shadow warning** — the speculative rebuild ran the branch-alias shadow check while the doomed alias was still attached, so a failed call logged a warning about a hierarchy state that was discarded microseconds later, phrased as though `definitions.py` were at fault. Shadow warnings now come only from construction, which is what they are for.
+
+### Removals
+
+- **`_to_l1()` and `_to_l0()` removed from `base_evaluator`** — superseded by `EntityHierarchy.to_branch()` / `to_binary()`, and callerless. `_to_l1` was a copy of the branch projection that did not learn alias resolution when `to_branch()` did, leaving the two disagreeing on 434 of 570 labels — including `LOC`, which `_to_l1` bucketed under a `LOC` branch of its own rather than `LOCATION`, the exact mis-bucketing branch aliases exist to remove. Nothing called it, so nothing miscounted; it is deleted rather than fixed so the divergence cannot be reintroduced by a future import.
+
 ## Version 0.3.2
 
 ### Features
@@ -11,11 +21,14 @@
 ### Breaking Changes
 
 - **`LOC`, `ORG` and `PER` are no longer canonical entities** — they were empty leaf nodes under `LOCATION`/`ORGANIZATION`/`PERSON` > `NAME` and are now branch-level aliases of `LOCATION`/`ORGANIZATION`/`PERSON`. Coarse dataset labels like TAB's `LOC`/`ORG`/`PER` therefore match a model's `LOCATION`/`ORGANIZATION`/`PERSON` at the exact (leaf) level, not only at the branch level. Concretely:
-  - `canonicalize("LOC")` returns `"LOCATION"` (was `"LOC"`), and likewise for `ORG` and `PER`.
-  - `LOC`/`ORG`/`PER` no longer appear in `all_canonical_entities` or `canonical_to_branch`.
-  - `get_depth("LOC")` returns `2` (was `3`), because `LOC` now denotes the depth-2 `LOCATION` branch. `get_depth("PER")` returns `2` (was `3`).
+  `LOC` and `ORG` were depth-3 canonical leaves, but `PER` sat one level deeper, under `PERSON > NAME`, so it does not follow the same before/after as the other two. Taking them separately:
+  - `canonicalize("LOC")` returns `"LOCATION"` (was `"LOC"`), and likewise `canonicalize("ORG")`.
+  - `canonicalize("PER")` returns `"PERSON"` — **was `"NAME"`**, not `"PER"`.
+  - `LOC` and `ORG` no longer appear in `all_canonical_entities` or `canonical_to_branch`. `PER` never did, being below the canonical depth.
+  - `get_depth("LOC")` returns `2` (was `3`), because `LOC` now denotes the depth-2 `LOCATION` branch. `get_depth("PER")` returns `2` — it previously **raised `EntityNotMappedError`**.
   - `CanonicalMapper.map()` no longer accepts `LOC`/`ORG`/`PER` as resolution *targets*, since targets must be canonical entities. Such mappings are also no longer needed — the labels resolve on their own.
-  - `to_branch("LOC")` still returns `"LOCATION"`, unchanged; `to_branch("PER")` still returns `"PERSON"`.
+  - `to_branch("LOC")` returns `"LOCATION"`, unchanged.
+  - **`to_branch("PER")` returns `"PERSON"`, where it previously returned `"PER"`.** This one is a genuine behaviour change, not a no-op: anyone bucketing a `PER`-annotated corpus by branch gets a different answer after upgrading. `PER` used to fall through `to_branch` unresolved and form a bucket of its own; it now joins `PERSON`.
 
 ### Behavior Changes
 

--- a/presidio_evaluator/entity_mapping/hierarchy.py
+++ b/presidio_evaluator/entity_mapping/hierarchy.py
@@ -136,7 +136,7 @@ class EntityHierarchy:
                 found = self._find_node(canonical)
         if found is None:
             raise KeyError(f"Entity {entity_name!r} not found in hierarchy")
-        parent_dict, key = found
+        parent_dict, key, path = found
         value = parent_dict[key]
         if isinstance(value, list):
             added_to = value
@@ -144,31 +144,47 @@ class EntityHierarchy:
             # Branch (non-leaf) node: record the alias under the reserved key so
             # it maps to this branch, instead of creating a spurious child leaf.
             added_to = value.setdefault(BRANCH_ALIASES_KEY, [])
+        # A pre-existing alias pointing elsewhere is a genuine conflict, and it
+        # has to be read BEFORE the append — afterwards the map has been rebuilt
+        # and cannot distinguish "was already taken" from "we just took it".
+        previously = self.raw_to_canonical.get(self.normalize(alias))
+        expected = self._canonical_name_for_path(path)
+        if previously is not None and previously != expected:
+            # Silently re-homing someone else's alias corrupts every corpus
+            # already annotated with it: add_alias("LOCATION", "EMAIL") used to
+            # be accepted and quietly moved EMAIL from EMAIL_ADDRESS to
+            # LOCATION, depending only on dict ordering.
+            raise ValueError(
+                f"Alias {alias!r} already resolves to {previously!r}, "
+                f"so it cannot be added to {key!r}",
+            )
         # Track whether THIS call appended, so a rollback never deletes an alias
         # that was already there (e.g. re-adding an alias the target already owns).
         appended = alias not in added_to
         if appended:
             added_to.append(alias)
-        self._rebuild()
+        self._rebuild(warn=False)
 
         # A branch alias is applied before the recursive descent into its own
         # subtree, so a descendant with the same normalized name wins. Rather
         # than persist an alias that silently never resolves, roll back and say
         # so — the caller's intent could not be honoured.
         #
-        # The alias is correct when it resolves wherever the TARGET resolves:
-        # for a node below canonical_depth that is the canonical ancestor, not
-        # the node's own name.
-        expected = self.raw_to_canonical.get(self.normalize(key))
+        # "Where the target lives" is computed from the node's PATH, not by
+        # asking where its name resolves. Those differ whenever another node
+        # claims the same name as an alias: the hierarchy has a canonical leaf
+        # LICENSE and also lists LICENSE as an alias of PROFESSIONAL_LICENSE, so
+        # raw_to_canonical["LICENSE"] is "PROFESSIONAL_LICENSE" and a name-based
+        # check rejected brand-new aliases that had landed exactly where asked.
         resolved = self.raw_to_canonical.get(self.normalize(alias))
         if resolved != expected:
             if appended:
                 added_to.remove(alias)
                 if not added_to and added_to is not value:
                     value.pop(BRANCH_ALIASES_KEY, None)
-                self._rebuild()
+            self._rebuild(warn=False)
             raise ValueError(
-                f"Alias {alias!r} already resolves to {resolved!r}, "
+                f"Alias {alias!r} is shadowed by {resolved!r}, "
                 f"so it cannot be added to {key!r}",
             )
 
@@ -284,8 +300,13 @@ class EntityHierarchy:
                 )
         return result
 
-    def _rebuild(self) -> None:
-        """Recompute raw_to_canonical, all_canonical_entities, and canonical_to_branch from the current hierarchy."""
+    def _rebuild(self, warn: bool = True) -> None:
+        """Recompute raw_to_canonical, all_canonical_entities, and canonical_to_branch from the current hierarchy.
+
+        *warn* is disabled by `add_alias`, whose speculative rebuilds describe
+        hierarchy states that are about to be discarded. Warning from those
+        would report a collision in `definitions.py` that never persisted.
+        """
         self.raw_to_canonical: dict[str, str] = self._build_alias_map(
             self.hierarchy,
             self.canonical_depth,
@@ -298,7 +319,8 @@ class EntityHierarchy:
             self.hierarchy,
             self.canonical_depth,
         )
-        self._warn_on_shadowed_branch_aliases()
+        if warn:
+            self._warn_on_shadowed_branch_aliases()
 
     def _warn_on_shadowed_branch_aliases(self) -> None:
         """Warn about branch aliases that a descendant silently overrides.
@@ -431,8 +453,15 @@ class EntityHierarchy:
         self,
         name: str,
         tree: dict | None = None,
-    ) -> tuple[dict, str] | None:
-        """Return (parent_dict, key) for the first node matching name in the hierarchy tree, or None."""
+        _path: tuple[str, ...] = (),
+    ) -> tuple[dict, str, tuple[str, ...]] | None:
+        """Return (parent_dict, key, path) for the first node matching name, or None.
+
+        *path* is the sequence of keys from the root down to and including the
+        node. It lets callers work out where a node actually sits in the tree
+        rather than asking what its name resolves to, which is not the same
+        question when another node claims that name as an alias.
+        """
         if tree is None:
             tree = self.hierarchy
         if name == BRANCH_ALIASES_KEY:
@@ -441,10 +470,27 @@ class EntityHierarchy:
             # to whichever branch happens to be found first).
             return None
         for key, value in tree.items():
+            if key == BRANCH_ALIASES_KEY:
+                continue
             if key == name:
-                return (tree, key)
+                return (tree, key, (*_path, key))
             if isinstance(value, dict):
-                result = self._find_node(name, value)
+                result = self._find_node(name, value, (*_path, key))
                 if result:
                     return result
         return None
+
+    def _canonical_name_for_path(self, path: tuple[str, ...]) -> str:
+        """Return the canonical name a node at *path* collapses into.
+
+        Mirrors `_build_alias_map`: nodes at or above `canonical_depth` are
+        canonical in their own right, and anything deeper folds into its
+        ancestor at `canonical_depth`.
+
+        This is deliberately structural. Asking `raw_to_canonical` where the
+        node's *name* resolves gives the wrong answer whenever a different node
+        claims that name as an alias — which is exactly the LICENSE case.
+        """
+        if len(path) > self.canonical_depth:
+            return path[self.canonical_depth - 1]
+        return path[-1]

--- a/presidio_evaluator/evaluation/base_evaluator.py
+++ b/presidio_evaluator/evaluation/base_evaluator.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 
 from presidio_evaluator import InputSample
-from presidio_evaluator.entity_mapping.hierarchy import EntityHierarchy
 from presidio_evaluator.evaluation import EvaluationResult
 from presidio_evaluator.evaluation.skipwords import get_skip_words
 from presidio_evaluator.models import BaseModel
@@ -17,23 +16,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 GENERIC_ENTITIES = ("PII", "ID", "PII", "PHI", "ID_NUM", "NUMBER", "NUM", "GENERIC_PII")
-
-
-def _to_l1(entity: str, hierarchy: EntityHierarchy) -> str:
-    """Map an entity label to its depth-2 (branch) ancestor."""
-    if entity == "O":
-        return "O"
-    branch = hierarchy.canonical_to_branch.get(entity)
-    if branch is None:
-        return entity  # unknown entity — pass through unchanged
-    if len(branch) >= 2:
-        return branch[1]  # e.g. ['PII', 'PERSON', 'NAME'] -> 'PERSON'
-    return branch[0]  # depth-1 node (PII itself)
-
-
-def _to_l0(entity: str) -> str:
-    """Map any non-O entity label to 'PII'."""
-    return "O" if entity == "O" else "PII"
 
 
 class DeprecationError(RuntimeError):

--- a/tests/entity_mapping/test_entity_hierarchy.py
+++ b/tests/entity_mapping/test_entity_hierarchy.py
@@ -656,3 +656,100 @@ class TestBranchAliases:
             EntityHierarchy()
         assert not [r for r in caplog.records if "shadowed" in r.message]
 
+
+
+class TestAddAliasShadowedTarget:
+    """Regression tests for the add_alias guard introduced with branch aliases.
+
+    Each of these fails on the commit that introduced branch aliases (2c61890).
+    """
+
+    def test_new_alias_on_license_is_accepted(self):
+        """LICENSE is the one node whose own name resolves somewhere else.
+
+        It is declared as a canonical leaf under EMPLOYMENT *and* as an alias of
+        PROFESSIONAL_LICENSE, so a guard that asks "where does the target's name
+        resolve?" gets PROFESSIONAL_LICENSE and rejects an alias that landed on
+        the LICENSE leaf exactly as asked.
+        """
+        h = EntityHierarchy()
+        assert h.normalize("PROF_LIC") not in h.raw_to_canonical
+        h.add_alias("LICENSE", "PROF_LIC")
+        assert h.canonicalize("PROF_LIC") == "LICENSE"
+
+    def test_every_canonical_entity_accepts_a_fresh_alias(self):
+        """No canonical entity may reject an alias nothing else has claimed.
+
+        This is the general form of the LICENSE bug: it caught one node out of
+        126, so a single hand-picked example could easily have missed it.
+        """
+        rejected = []
+        for entity in sorted(EntityHierarchy().all_canonical_entities):
+            h = EntityHierarchy()
+            try:
+                h.add_alias(entity, f"ZZ_FRESH_{entity}")
+            except ValueError:
+                rejected.append(entity)
+        assert rejected == []
+
+    def test_alias_owned_by_another_entity_is_refused(self):
+        """Re-homing a live alias silently invalidates existing annotations."""
+        h = EntityHierarchy()
+        assert h.canonicalize("EMAIL") == "EMAIL_ADDRESS"
+        with pytest.raises(ValueError, match="already resolves"):
+            h.add_alias("LOCATION", "EMAIL")
+        assert h.canonicalize("EMAIL") == "EMAIL_ADDRESS"
+
+    def test_refused_alias_leaves_hierarchy_untouched(self):
+        h = EntityHierarchy()
+        before = dict(h.raw_to_canonical)
+        for target, alias in (("LOCATION", "EMAIL"), ("LOCATION", "CITY")):
+            with pytest.raises(ValueError):
+                h.add_alias(target, alias)
+        assert h.raw_to_canonical == before
+
+    def test_rejected_add_alias_does_not_warn(self, caplog):
+        """The warning is about definitions.py, not about a rejected argument."""
+        import logging
+
+        h = EntityHierarchy()
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(ValueError):
+                h.add_alias("LOCATION", "CITY")
+        assert [r for r in caplog.records if "shadowed" in r.message] == []
+
+    def test_construction_still_warns_about_static_shadowing(self, caplog):
+        """Silencing the probe rebuild must not silence the real check."""
+        import copy
+        import logging
+
+        hier = copy.deepcopy(HIERARCHY)
+        hier["PII"]["LOCATION"][BRANCH_ALIASES_KEY] = ["LOC", "CITY"]
+        with caplog.at_level(logging.WARNING):
+            EntityHierarchy(hierarchy=hier)
+        assert any("shadowed" in r.message for r in caplog.records)
+
+    def test_canonical_name_for_path_uses_structure_not_names(self):
+        h = EntityHierarchy()
+        found = h._find_node("LICENSE")
+        assert found is not None
+        _, key, path = found
+        assert key == "LICENSE"
+        assert h._canonical_name_for_path(path) == "LICENSE"
+        # ...whereas the name-based question gives a different answer, which is
+        # precisely why the guard must not ask it.
+        assert h.canonicalize("LICENSE") == "PROFESSIONAL_LICENSE"
+
+
+class TestRemovedBranchProjectionHelpers:
+    def test_to_l1_and_to_l0_are_gone(self):
+        """Deleted so no future import can resurrect the diverged copy."""
+        from presidio_evaluator.evaluation import base_evaluator
+
+        assert not hasattr(base_evaluator, "_to_l1")
+        assert not hasattr(base_evaluator, "_to_l0")
+
+    def test_to_branch_resolves_aliases_that_to_l1_did_not(self):
+        h = EntityHierarchy()
+        assert h.to_branch("LOC") == "LOCATION"
+        assert h.to_branch("CITY") == "LOCATION"


### PR DESCRIPTION
Follow-up to #186. @omri374 left a second review round on Aug 17; #186 was merged on Aug 18 without those comments being answered. My mistake — this addresses all four.

## 1. `add_alias()` rejected a valid alias on `LICENSE`

The rollback guard asked where the *target's name* resolves and compared that to where the new alias landed. Same question for every node but one: the hierarchy declares `LICENSE` both as a canonical leaf under `EMPLOYMENT` and as an alias of `PROFESSIONAL_LICENSE`, so `canonicalize("LICENSE") == "PROFESSIONAL_LICENSE"`.

```py
h.add_alias("LICENSE", "PROF_LIC")
# ValueError: Alias 'PROF_LIC' already resolves to 'LICENSE'
```

`PROF_LIC` was brand new — the mapping being reported as a conflict was the one the call created one line earlier, exactly as described in review. The guard now derives the target from the node's **path** in the tree, so another node claiming the same name can't confuse it.

Swept all 126 canonical entities: **1 rejected a fresh alias before, 0 now.**

## 2. `add_alias()` silently stole aliases from other entities

Found while fixing (1). `add_alias("LOCATION", "EMAIL")` was *accepted* and quietly re-pointed `EMAIL` from `EMAIL_ADDRESS` to `LOCATION` — invalidating any corpus annotated with that label, succeeding or failing purely on dict ordering. Pre-existing, not from #186, but the fix above already required reading the alias's prior owner, so it's a two-line check. Now refused before the hierarchy is touched.

## 3. Rejected `add_alias()` logged a spurious shadow warning

The speculative rebuild ran the shadow check while the doomed alias was still attached, so a failed call warned about a state discarded microseconds later, worded as though `definitions.py` were at fault. `_rebuild()` now takes `warn=False` for probe rebuilds; construction still warns.

## 4. `_to_l1()` / `_to_l0()` removed

Deleted rather than taught about aliases, per the review suggestion. `_to_l1` was a copy of the branch projection that never learned alias resolution, leaving it disagreeing with `to_branch()` on 434/570 labels — including `LOC`, bucketed under a `LOC` branch of its own instead of `LOCATION`, the exact mis-bucketing #186 exists to remove. Callerless, so nothing miscounted; deleting it means a future import can't resurrect the divergence.

## CHANGELOG correction

The #186 entry described `PER` as behaving like `LOC`/`ORG`. It didn't — `PER` was a depth-4 leaf under `PERSON > NAME`. Verified against `1663688` (the commit before #186); the review's table is correct on all four rows:

| claim in #186 | actual before | now |
|---|---|---|
| `canonicalize("PER")` was `"PER"` | `'NAME'` | `'PERSON'` |
| `PER` no longer in `all_canonical_entities` | already absent | absent |
| `get_depth("PER")` was `3` | raised `EntityNotMappedError` | `2` |
| `to_branch("PER")` "still returns `PERSON`" | `'PER'` — **it did change** | `'PERSON'` |

That last row is now called out as a behaviour change rather than filed under "unchanged".

## Verification

9 tests added. **7 fail on `2c61890`**; the other 2 are controls that must keep passing (construction still warns; `to_branch` resolves aliases). **737 passed, 2 skipped**; `ruff` clean.
