### PR TITLE
Fix HospitalProvider WikiData 403 by sending a User-Agent header

### DIFF
--- a/presidio_evaluator/data_generator/faker_extensions/providers.py
+++ b/presidio_evaluator/data_generator/faker_extensions/providers.py
@@ -326,10 +326,24 @@ class HospitalProvider(BaseProvider):
         }
 
         """
+        headers = {
+            "User-Agent": (
+                "presidio-research "
+                "(https://github.com/data-privacy-stack/presidio-research)"
+            )
+        }
         try:
-            r = requests.get(url, params={"format": "json", "query": query}, timeout=10)
+            r = requests.get(
+                url,
+                params={"format": "json", "query": query},
+                headers=headers,
+                timeout=10,
+            )
             if r.status_code != 200:
-                print("Unable to read hospitals from WikiData, returning an empty list")
+                print(
+                    "Unable to read hospitals from WikiData "
+                    f"(status code {r.status_code}), returning default hospital list"
+                )
                 return self.default_list
             data = r.json()
             bindings = data["results"].get("bindings", [])

--- a/tests/data_generator/test_providers.py
+++ b/tests/data_generator/test_providers.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 from faker import Faker
 
 from presidio_evaluator.data_generator.faker_extensions import (
@@ -26,3 +28,29 @@ def test_hospital_provider():
     faker.add_provider(HospitalProvider)
     element = faker.hospital_name()
     assert element
+
+
+@patch("presidio_evaluator.data_generator.faker_extensions.providers.requests.get")
+def test_hospital_provider_sends_user_agent_header(mock_get):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"results": {"bindings": []}}
+    mock_get.return_value = mock_response
+
+    faker = Faker()
+    faker.add_provider(HospitalProvider)
+
+    _, call_kwargs = mock_get.call_args
+    assert "User-Agent" in call_kwargs["headers"]
+
+
+@patch("presidio_evaluator.data_generator.faker_extensions.providers.requests.get")
+def test_hospital_provider_falls_back_on_non_200_response(mock_get):
+    mock_response = MagicMock()
+    mock_response.status_code = 403
+    mock_get.return_value = mock_response
+
+    faker = Faker()
+    provider = HospitalProvider(faker)
+
+    assert provider.hospitals == provider.default_list


### PR DESCRIPTION
WikiData now rejects unauthenticated requests to its SPARQL endpoint with a 403
and a message asking clients to set a User-Agent per its robot policy
(https://w.wiki/4wJS). This made `HospitalProvider.load_wiki_hospitals()` silently
fall back to its hardcoded default hospital list on every call.

Repro (from #173):
> Using default entity providers
> Unable to read hospitals from WikiData, returning an empty list
> ...
The WikiData endpoint returns 403 with: "Please set a user-agent and respect
our robot policy https://w.wiki/4wJS."

This PR:
- Adds a `User-Agent` header to the `requests.get` call in
  `providers.py::load_wiki_hospitals`.
- Fixes the log message on the fallback path, which said "returning an empty
  list" when the code actually returns `self.default_list`.
- Adds two unit tests covering the header being sent and the fallback behavior
  on a non-200 response.

Fixes #173

---
Disclosure: I'm the author of phi-gate (https://github.com/jbisaccia-9/phi-gate),
an independent PHI redaction gate — no affiliation with this project.