### PR TITLE
fix: i2b2 PATIENT is a person name, not a medical record number

### DIFF
--- a/presidio_evaluator/entity_mapping/definitions.py
+++ b/presidio_evaluator/entity_mapping/definitions.py
@@ -32,6 +32,7 @@ HIERARCHY: dict = {
                 "FULL_NAME": [
                     "FULLNAME",
                     "DOCTOR",
+                    "PATIENT",
                     "PATIENT_NAME",
                     "DOCTOR_NAME",
                     "HCW",
@@ -361,7 +362,6 @@ HIERARCHY: dict = {
         },
         "PHI": {
             "PATIENT_ID": [
-                "PATIENT",
                 "MEDICALRECORD",
                 "MEDICAL_RECORD_NUMBER",
                 "MEDICAL_RECORD",

--- a/tests/entity_mapping/test_entity_hierarchy.py
+++ b/tests/entity_mapping/test_entity_hierarchy.py
@@ -656,3 +656,23 @@ class TestBranchAliases:
             EntityHierarchy()
         assert not [r for r in caplog.records if "shadowed" in r.message]
 
+
+    def test_i2b2_patient_is_a_name_not_a_record_number(self):
+        # In the i2b2/n2c2 2014 de-identification schema, PATIENT and DOCTOR are
+        # both subtypes of the NAME category; MEDICALRECORD is the ID subtype.
+        # "PATIENT" tags a person's name ("Yosef Villegas"), so it must resolve
+        # like DOCTOR and PATIENT_NAME, not like a medical record number.
+        for label in ("PATIENT", "DOCTOR", "PATIENT_NAME"):
+            assert self.h.canonicalize(label) == "NAME"
+            assert self.h.to_branch(label) == "PERSON"
+
+        # ...while the record-number aliases stay in PHI.
+        for label in ("MEDICALRECORD", "MEDICAL_RECORD"):
+            assert self.h.canonicalize(label) == "PATIENT_ID"
+            assert self.h.to_branch(label) == "PHI"
+
+        # MEDICAL_RECORD_NUMBER is listed under both PATIENT_ID and MRN, and MRN
+        # currently wins. That pre-existing shadowing is out of scope here; it is
+        # asserted at branch level so this test does not silently encode which
+        # leaf happens to win.
+        assert self.h.to_branch("MEDICAL_RECORD_NUMBER") == "PHI"


### PR DESCRIPTION
## Problem

`"PATIENT"` is an alias of the **`PATIENT_ID`** leaf — the same leaf as `MEDICALRECORD`.

In the [i2b2/n2c2 2014 de-identification schema](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4989908/), `PATIENT` and `DOCTOR` are both subtypes of the **NAME** category, while `MEDICALRECORD` is a subtype of **ID**. The `PATIENT` tag marks a person's name, not an identifier. Real gold values from the n2c2 2014 test set:

```
PATIENT        -> "Villegas", "Villegas, Yosef", "Yosef Villegas"
MEDICALRECORD  -> "8249813", "560-40-78-5"
```

The hierarchy already handled every neighbouring label correctly, which made bare `PATIENT` the odd one out:

| label | canonical | branch | |
|---|---|---|---|
| `PATIENT` | `PATIENT_ID` | `PHI` | ⬅ wrong |
| `PATIENT_NAME` | `NAME` | `PERSON` | |
| `DOCTOR` | `NAME` | `PERSON` | |
| `DOCTOR_NAME` | `NAME` | `PERSON` | |
| `HCW` | `NAME` | `PERSON` | |

## Why it matters

The mismatch is at **branch** level as well as leaf level, so it is not recoverable by relaxing the scoring level. A model that correctly calls a patient name a `NAME` is scored wrong at Exact *and* Categorical, while a model that reproduces the mislabel is scored right.

On a 20-record n2c2 sample this covered **32 of 328 gold spans (~10%)**. In our benchmark it inverted a comparison: an encoder emitting the correct `NAME` scored **0.000** on that type and showed up 38 times as `gold PATIENT_ID -> predicted NAME`, while a prompted model configured to emit `PATIENT` scored well. Correcting the mapping moved that encoder's n2c2 Exact P/R from `0.569/0.573` to `0.655/0.639`.

## Change

Move `"PATIENT"` to `FULL_NAME`, alongside `DOCTOR` and `PATIENT_NAME`. The record-number aliases (`MEDICALRECORD`, `MEDICAL_RECORD`) stay on `PATIENT_ID`.

```python
PATIENT        -> NAME        branch PERSON
MEDICALRECORD  -> PATIENT_ID  branch PHI
```

## Tests

Adds `test_i2b2_patient_is_a_name_not_a_record_number`. Full suite: **729 passed, 2 skipped**.

---

# ⚠️ Second bug found while writing the test — NOT fixed here

`MEDICAL_RECORD_NUMBER` is listed as an alias of **two different leaves**, and nothing warns about it:

https://github.com/data-privacy-stack/presidio-research/blob/fix/patient-is-a-name/presidio_evaluator/entity_mapping/definitions.py#L364-L366

```python
"PATIENT_ID": [
    ...
    "MEDICAL_RECORD_NUMBER",   # line 366
    ...
],
...
"MRN": ["MEDICAL_RECORD_NUMBER"],   # line 397  <- silently wins
```

**`MRN` wins**, so three labels that mean the same thing land on two different leaves:

| label | canonical | branch |
|---|---|---|
| `MEDICALRECORD` | `PATIENT_ID` | `PHI` |
| `MEDICAL_RECORD` | `PATIENT_ID` | `PHI` |
| `MEDICAL_RECORD_NUMBER` | **`MRN`** | `PHI` |

So a model predicting `MRN` against gold `MEDICALRECORD` (or vice versa) is **counted wrong at Exact level** purely on spelling. It happens to be harmless at Categorical/branch level today only because both leaves sit under `PHI` — that is luck, not design.

`_warn_on_shadowed_branch_aliases` does not catch this, because it only checks *branch* aliases; duplicate **leaf** aliases are silently resolved by insertion order.

I deliberately left this out of scope so the PR stays a one-line fix. The new test asserts `MEDICAL_RECORD_NUMBER` at **branch level only**, so it does not bake in whichever leaf currently happens to win.

**Two follow-ups worth considering, happy to open issues or a second PR:**
1. Collapse `MRN` into `PATIENT_ID` (or vice versa) so the synonyms agree.
2. Extend the shadowing warning to cover leaf-level duplicate aliases, so the next one of these is caught automatically rather than by accident.
