### PR TITLE
Improve hospital provider robustness and API compliance

### DIFF
--- a/presidio_evaluator/data_generator/faker_extensions/providers.py
+++ b/presidio_evaluator/data_generator/faker_extensions/providers.py
@@ -298,7 +298,7 @@ class HospitalProvider(BaseProvider):
 
         if hospital_file:
             hospitals = pd.read_csv(hospital_file)
-            if "name" not in self.hospitals:
+            if "name" not in hospitals:
                 print(
                     "Unable to retrieve hospital names, "
                     "file is missing column named 'name'",
@@ -346,10 +346,10 @@ class HospitalProvider(BaseProvider):
                 )
                 return self.default_list
             data = r.json()
-            bindings = data["results"].get("bindings", [])
+            bindings = data.get("results", {}).get("bindings", [])
             hospitals = [self.deep_get(x, ["label_en", "value"]) for x in bindings]
             hospitals = [x for x in hospitals if "no key" not in x]
-            return hospitals
+            return hospitals if hospitals else self.default_list
         except OSError:
             warnings.warn(
                 "Can't download hospitals data. Returning default list", stacklevel=2

--- a/tests/data_generator/test_providers.py
+++ b/tests/data_generator/test_providers.py
@@ -40,6 +40,7 @@ def test_hospital_provider_sends_user_agent_header(mock_get):
     faker = Faker()
     faker.add_provider(HospitalProvider)
 
+    mock_get.assert_called_once()
     _, call_kwargs = mock_get.call_args
     assert "User-Agent" in call_kwargs["headers"]
 


### PR DESCRIPTION
## Summary
This PR enhances the `HospitalProvider` class to be more robust when fetching hospital data from external APIs and fixes a bug in the CSV file validation logic.

## Key Changes
- **Add User-Agent header to WikiData API requests**: The `load_wiki_hospitals` method now includes a proper User-Agent header identifying the presidio-research project, which is a best practice for API requests and may be required by some API providers.

- **Improve error handling for non-200 responses**: When the WikiData API returns a non-200 status code, the provider now falls back to the default hospital list instead of attempting to parse the response. The error message is also more informative, including the actual status code.

- **Fix CSV validation bug**: Corrected a logic error in `load_hospitals` where the code was checking `if "name" not in self.hospitals` instead of `if "name" not in hospitals`, which would have always failed since `self.hospitals` is a list, not a dictionary.

- **Improve JSON parsing robustness**: Changed `data["results"].get("bindings", [])` to `data.get("results", {}).get("bindings", [])` to safely handle cases where the "results" key might be missing from the API response.

- **Return default list on empty results**: When the API returns a successful response but with no hospital data, the provider now returns the default list instead of an empty list.

## Testing
Added two new test cases:
- `test_hospital_provider_sends_user_agent_header`: Verifies that the User-Agent header is included in API requests
- `test_hospital_provider_falls_back_on_non_200_response`: Verifies that the provider falls back to the default list when receiving non-200 responses

https://claude.ai/code/session_01GQdDt3jNx7xrcwYtqbJ2n1