### PR TITLE
Update CI workflow to remove Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Removed Python version 3.10 from CI workflow matrix.